### PR TITLE
fix: ignore .dev.vars, organize .gitignore, and fix duplicates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # build output
 dist/
 .astro/
-.env
 .obsidian/
 src/content/posts/.obsidian/
 
@@ -17,6 +16,7 @@ pnpm-debug.log*
 # environment variables
 .env
 .env.production
+.dev.vars
 
 # macOS-specific files
 .DS_Store


### PR DESCRIPTION
- Migrating from .env to .dev.vars, as recommended in Cloudflare Workers documentation
- Organize .gitignore
- Fixed duplicate .env entries