### PR TITLE
fix: remove Cloudflare adapter

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,14 +2,10 @@
 import { defineConfig, fontProviders } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import tailwindcss from '@tailwindcss/vite';
-import cloudflare from '@astrojs/cloudflare';
-
 
 // https://astro.build/config
 export default defineConfig({
   site: 'https://kyleio.com',
-  // output: 'static', // Allows static pages + API routes
-  adapter: cloudflare(),
   integrations: [mdx()],
   experimental: {
     fonts: [


### PR DESCRIPTION
It's not needed for a static site and isn't related to the raindrop API fix I'm working on