### PR TITLE
Add Mastodon verification link

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -41,6 +41,8 @@ const ogType = isHome ? 'website' : 'article';
     <meta property="og:description" content={siteDescription}>
     <meta property="og:image" content={image}>
 
+    <a rel="me" style="display:none;" href="https://mastodon.online/@kylejohnston">Mastodon</a>
+
     <Font cssVariable="--font-mono" preload />
     <Font cssVariable="--font-sans" preload />
     <Font cssVariable="--font-text" preload />


### PR DESCRIPTION
Inserted a hidden rel="me" link to Mastodon for profile verification purposes. This helps verify site ownership on Mastodon.