### PR TITLE
fix(rss): handle multi-line MDX components without leaking JSX as text

### DIFF
--- a/notes/rss-feed-options.md
+++ b/notes/rss-feed-options.md
@@ -1,0 +1,50 @@
+# RSS feed: future-direction options
+
+Captured 2026-05-04. The current implementation (`src/pages/rss.xml.ts`) uses a JSX-aware scanner to strip MDX components from post bodies, then renders the remaining markdown via `micromark`. For posts with a `galleryPath` frontmatter field, it appends static `<img>` HTML built from `import.meta.glob`. This works for today's posts.
+
+Two larger directions were considered and deferred. Revisit when adding components that need richer feed treatment.
+
+## Option 2 — Generate RSS from the built `dist/` HTML
+
+Replace the route at `src/pages/rss.xml.ts` with a post-build script. After `astro build` runs, the script reads each rendered post HTML (`dist/p/<slug>/index.html`), extracts the article content, sanitizes it, rewrites relative URLs to absolute, appends the existing RSS footer, and writes `dist/rss.xml`.
+
+Wiring options:
+- An npm script: `"build": "astro build && tsx scripts/generate-rss.ts"`.
+- An Astro integration using the `astro:build:done` hook. Cleaner — runs in the same build process and receives the dist directory as input.
+
+This works because `wrangler.jsonc` deploys `./dist` as static assets, so the rendered HTML is the source of truth.
+
+Pros:
+- One rendering pipeline. Anything that renders on the page renders in RSS.
+- New components automatically work without RSS-specific code.
+- No JSX stripping or per-component handling.
+
+Cons / things to design:
+- Need a stable selector that bounds "article content" — likely add `<article data-rss-content>` (or similar) around the post body in `src/pages/p/[...slug].astro`.
+- Interactive bits (e.g. `GalleryGrid` React lightbox) must degrade gracefully. Static thumbnail grid is fine; strip `<script>` and `client:*` artifacts.
+- Be careful what CSS/HTML chrome leaks in. Sanitize aggressively with `ultrahtml` (already a dep).
+- The current route at `src/pages/rss.xml.ts` would be removed.
+
+Effort: medium. Worth it when there are 2+ custom components beyond Gallery, or when feed fidelity matters more.
+
+## Option 3 — Per-component RSS render contract
+
+Generalize what `galleryPath` already does: each component that wouldn't survive plain markdown rendering exports (or registers) a static `rssRender(props)` function. RSS generation parses the MDX body to an AST (via `@mdx-js/mdx`, already on the dependency tree through `@astrojs/mdx`), walks it, and for each known component name calls the component's `rssRender` to produce static HTML. Unknown components get dropped.
+
+Pros:
+- Components own their feed representation in code, next to the component itself.
+- No regex or string scanning. AST-based.
+- Predictable, opt-in per component.
+
+Cons:
+- More code than the current scanner, less universal than Option 2.
+- Each new component needs an explicit `rssRender` to appear in feeds.
+- Props passed in MDX may include runtime values (`import.meta.glob` results) that aren't trivially serializable from an AST without re-evaluating the module — likely need to resolve images via the same `import.meta.glob` approach used today, keyed off props or frontmatter.
+
+Effort: low–medium. Good fit if RSS-specific representation differs meaningfully from web rendering for several components.
+
+## When to revisit
+
+- Adding a third custom component that renders meaningfully in posts → consider Option 3.
+- Adding interactive content where readers should still see something useful in the feed (charts, embeds, etc.) → consider Option 2.
+- If `import.meta.glob`-based gallery handling becomes painful to maintain across many `galleryPath` variants → either option helps.

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -39,6 +39,116 @@ function getGalleryHtml(galleryPath: string, baseUrl: string): string {
   return `<div>${imgTags}</div>`;
 }
 
+// Remove MDX/JSX components (<Capital ... /> or <Capital ...>...</Capital>) from
+// a markdown body. Unlike a plain regex, this scanner respects strings, template
+// literals, and `{...}` JSX expressions, so `>` characters inside props (e.g.
+// embedded HTML in a `captions` object) don't terminate the match prematurely.
+function stripMdxComponents(input: string): string {
+  let out = "";
+  let i = 0;
+  while (i < input.length) {
+    if (input[i] === "<" && /[A-Z]/.test(input[i + 1] ?? "")) {
+      const end = skipComponent(input, i);
+      if (end > i) {
+        i = end;
+        continue;
+      }
+    }
+    out += input[i];
+    i++;
+  }
+  return out;
+}
+
+function skipComponent(input: string, start: number): number {
+  let p = start + 1;
+  const nameStart = p;
+  while (p < input.length && /[A-Za-z0-9_.]/.test(input[p])) p++;
+  const name = input.slice(nameStart, p);
+  if (!name || !/^[A-Z]/.test(name)) return start;
+
+  const opening = readTagBody(input, p);
+  if (!opening) return start;
+  if (opening.selfClosing) return opening.end;
+
+  let depth = 1;
+  let q = opening.end;
+  while (q < input.length) {
+    if (input[q] === "<") {
+      // Closing tag </Name>?
+      if (
+        input[q + 1] === "/" &&
+        input.slice(q + 2, q + 2 + name.length) === name
+      ) {
+        const after = input[q + 2 + name.length];
+        if (after === ">" || after === undefined || /\s/.test(after)) {
+          const close = input.indexOf(">", q + 2 + name.length);
+          if (close === -1) return start;
+          depth--;
+          if (depth === 0) return close + 1;
+          q = close + 1;
+          continue;
+        }
+      }
+      // Nested same-name opening tag?
+      if (input.slice(q + 1, q + 1 + name.length) === name) {
+        const after = input[q + 1 + name.length] ?? "";
+        if (after === ">" || after === "/" || /\s/.test(after)) {
+          const nested = readTagBody(input, q + 1 + name.length);
+          if (nested) {
+            if (!nested.selfClosing) depth++;
+            q = nested.end;
+            continue;
+          }
+        }
+      }
+    }
+    q++;
+  }
+  return start;
+}
+
+function readTagBody(
+  input: string,
+  p: number
+): { end: number; selfClosing: boolean } | null {
+  let braces = 0;
+  let str: string | null = null;
+  while (p < input.length) {
+    const c = input[p];
+    if (str !== null) {
+      if (c === "\\") {
+        p += 2;
+        continue;
+      }
+      if (c === str) str = null;
+      p++;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      str = c;
+      p++;
+      continue;
+    }
+    if (c === "{") {
+      braces++;
+      p++;
+      continue;
+    }
+    if (c === "}") {
+      if (braces > 0) braces--;
+      p++;
+      continue;
+    }
+    if (braces === 0) {
+      if (c === "/" && input[p + 1] === ">") return { end: p + 2, selfClosing: true };
+      if (c === ">") return { end: p + 1, selfClosing: false };
+    }
+    p++;
+  }
+  return null;
+}
+
 export async function GET(context: APIContext) {
   // Get the URL to prepend to relative site links. Based on `site` in `astro.config.mjs`.
   let baseUrl = context.site?.href || "https://kyleio.com";
@@ -93,12 +203,11 @@ export async function GET(context: APIContext) {
         }
       ) || '';
 
-      const markdown = bodyWithYouTube
-        .replace(/^import .+$/gm, '')       // strip import statements
-        .replace(/^export .+$/gm, '')         // strip export statements
-        .replace(/<[A-Z]\w*[^>]*\/>/g, '')    // strip self-closing JSX components
-        .replace(/<[A-Z]\w*[^>]*>[\s\S]*?<\/[A-Z]\w*>/g, '') // strip JSX blocks
-        .trim();
+      const markdown = stripMdxComponents(
+        bodyWithYouTube
+          .replace(/^import .+$/gm, '')   // strip import statements
+          .replace(/^export .+$/gm, '')   // strip export statements
+      ).trim();
       const markdownHtml = micromark(markdown);
       if (post.data.galleryPath) {
         const galleryHtml = getGalleryHtml(post.data.galleryPath, baseUrl);


### PR DESCRIPTION
The previous JSX stripper used a regex `<[A-Z]\w*[^>]*\/>` that stopped at the first `>`. When a component spanned multiple lines or contained embedded HTML inside props (e.g. a `captions` prop with `<a href='...'>`), the regex never reached the closing `/>` and the raw `<Gallery ... />` JSX leaked into RSS feeds as escaped text.

Replace the regex pair with a small JSX-aware scanner that respects strings, template literals, and `{...}` expression depth, and walks nested same-name tags. Also document two larger structural alternatives (post-build dist/ extraction, per-component rssRender contract) in notes/rss-feed-options.md for future revisits.